### PR TITLE
Speed up webpack by excluding node_modules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,7 @@ module.exports = {
         loaders: [
             {
                 test: /\.js/,
+                exclude: /node_modules/,
                 loaders: ['transform?brfs', 'babel-loader?stage=0']
             },
             {


### PR DESCRIPTION
This change improves build speed from over 3 minutes to 34 seconds on a machine with Atom CPU.
